### PR TITLE
Rename aws_instance resource from 'blog' to 'webblog'

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ data "aws_ami" "app_ami" {
 
   owners = ["979382823631"] # Bitnami
 }
-resource "aws_instance" "blog" {
+resource "aws_instance" "webblog" {
   ami           = data.aws_ami.app_ami.id
   instance_type = var.instance_type
 


### PR DESCRIPTION
changed the instance name