### PR TITLE
Fix bitnami AMI name filter pattern

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ data "aws_ami" "app_ami" {
 
   filter {
     name   = "name"
-    values = ["bitnami-tomcat-*-x86_64-hvm-ebs-nami"]
+    values = ["bitnami-tomcat-*"]
   }
 
   filter {


### PR DESCRIPTION
Broaden the name filter from the legacy suffix pattern to a wildcard so the data source resolves against current Bitnami AMI naming conventions.